### PR TITLE
fix: redact action-scoped AWS credentials

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.2.8
+    rev: v2.2.9
     hooks:
       - id: build-docs
         language: python

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,13 +8,13 @@ default_stages: [pre-commit]
 # This is a template for connector pre-commit hooks
 repos:
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v4.1.0
+    rev: v4.4.0
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
         args: [--verbose]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer
@@ -27,13 +27,13 @@ repos:
       - id: check-json
       - id: check-yaml
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.7
+    rev: v0.16.1
     hooks:
       - id: ruff
         args: [ "--fix", "--unsafe-fixes"] # Allow unsafe fixes (ruff pretty strict about what it can fix)
       - id: ruff-format
   - repo: https://github.com/djlint/djLint
-    rev: v1.36.4
+    rev: v1.43.1
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
@@ -43,12 +43,12 @@ repos:
       - id: soar-app-linter
         args: ["--single-repo", "--message-level", "error"]
   - repo: https://github.com/hukkin/mdformat
-    rev: 0.7.22
+    rev: 1.0.0
     hooks:
       - id: mdformat
         exclude: "release_notes/.*"
   - repo: https://github.com/returntocorp/semgrep
-    rev: v1.136.0
+    rev: v1.165.0
     hooks:
       - id: semgrep
         additional_dependencies: ["setuptools==81.0.0"]
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.4
+    rev: v2.2.8
     hooks:
       - id: build-docs
         language: python

--- a/NOTICE
+++ b/NOTICE
@@ -665,4 +665,3 @@ Notice:
 
 s3transfer
 Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-

--- a/README.md
+++ b/README.md
@@ -147,7 +147,6 @@ action_result.summary.status | string | | Successfully executed program |
 action_result.message | string | | Status: Successfully executed program, Created vault id: 6f3832d6a9dd6e41533f9648052c07f2379ec6fa |
 summary.total_objects | numeric | | 1 2 |
 summary.total_objects_successful | numeric | | 1 0 |
-action_result.parameter.credentials | password | `aws credentials` | |
 
 ## action: 'get file'
 
@@ -213,7 +212,6 @@ action_result.summary.status | string | | Successfully downloaded file into the 
 action_result.message | string | | Status: Successfully downloaded file into the vault, Created vault id: 3fa5db539d7bceec01ac4c100481aa5682766d33 |
 summary.total_objects | numeric | | 1 |
 summary.total_objects_successful | numeric | | 1 |
-action_result.parameter.credentials | password | `aws credentials` | |
 
 ## action: 'run document'
 
@@ -288,7 +286,6 @@ action_result.summary.status | string | | Successfully sent command |
 action_result.message | string | | Status: Successfully sent command |
 summary.total_objects | numeric | | 1 |
 summary.total_objects_successful | numeric | | 1 |
-action_result.parameter.credentials | password | `aws credentials` | |
 
 ## action: 'list commands'
 
@@ -355,7 +352,6 @@ action_result.summary.num_commands | numeric | | 43 1 |
 action_result.message | string | | Num commands: 43 Num commands: 1 |
 summary.total_objects | numeric | | 1 |
 summary.total_objects_successful | numeric | | 1 |
-action_result.parameter.credentials | password | `aws credentials` | |
 
 ## action: 'list documents'
 
@@ -397,7 +393,6 @@ action_result.summary.num_documents | numeric | | 5 |
 action_result.message | string | | Num documents: 5 |
 summary.total_objects | numeric | | 1 |
 summary.total_objects_successful | numeric | | 1 |
-action_result.parameter.credentials | password | `aws credentials` | |
 
 ## action: 'get parameter'
 
@@ -440,7 +435,6 @@ action_result.summary.status | string | | Successfully retrieved parameter |
 action_result.message | string | | Status: Successfully retrieved parameter |
 summary.total_objects | numeric | | 1 |
 summary.total_objects_successful | numeric | | 1 |
-action_result.parameter.credentials | password | `aws credentials` | |
 
 ## action: 'add parameter'
 
@@ -490,7 +484,6 @@ action_result.summary.status | string | | Successfully added parameter |
 action_result.message | string | | Status: Successfully added parameter |
 summary.total_objects | numeric | | 1 |
 summary.total_objects_successful | numeric | | 1 |
-action_result.parameter.credentials | password | `aws credentials` | |
 
 ## action: 'describe instance'
 
@@ -541,7 +534,6 @@ action_result.summary.status | string | | Successfully retrieved instance inform
 action_result.message | string | | Status: Successfully retrieved instance information |
 summary.total_objects | numeric | | 1 |
 summary.total_objects_successful | numeric | | 1 |
-action_result.parameter.credentials | password | `aws credentials` | |
 
 ______________________________________________________________________
 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ action_result.summary.status | string | | Successfully executed program |
 action_result.message | string | | Status: Successfully executed program, Created vault id: 6f3832d6a9dd6e41533f9648052c07f2379ec6fa |
 summary.total_objects | numeric | | 1 2 |
 summary.total_objects_successful | numeric | | 1 0 |
+action_result.parameter.credentials | password | `aws credentials` | |
 
 ## action: 'get file'
 
@@ -212,6 +213,7 @@ action_result.summary.status | string | | Successfully downloaded file into the 
 action_result.message | string | | Status: Successfully downloaded file into the vault, Created vault id: 3fa5db539d7bceec01ac4c100481aa5682766d33 |
 summary.total_objects | numeric | | 1 |
 summary.total_objects_successful | numeric | | 1 |
+action_result.parameter.credentials | password | `aws credentials` | |
 
 ## action: 'run document'
 
@@ -286,6 +288,7 @@ action_result.summary.status | string | | Successfully sent command |
 action_result.message | string | | Status: Successfully sent command |
 summary.total_objects | numeric | | 1 |
 summary.total_objects_successful | numeric | | 1 |
+action_result.parameter.credentials | password | `aws credentials` | |
 
 ## action: 'list commands'
 
@@ -352,6 +355,7 @@ action_result.summary.num_commands | numeric | | 43 1 |
 action_result.message | string | | Num commands: 43 Num commands: 1 |
 summary.total_objects | numeric | | 1 |
 summary.total_objects_successful | numeric | | 1 |
+action_result.parameter.credentials | password | `aws credentials` | |
 
 ## action: 'list documents'
 
@@ -393,6 +397,7 @@ action_result.summary.num_documents | numeric | | 5 |
 action_result.message | string | | Num documents: 5 |
 summary.total_objects | numeric | | 1 |
 summary.total_objects_successful | numeric | | 1 |
+action_result.parameter.credentials | password | `aws credentials` | |
 
 ## action: 'get parameter'
 
@@ -435,6 +440,7 @@ action_result.summary.status | string | | Successfully retrieved parameter |
 action_result.message | string | | Status: Successfully retrieved parameter |
 summary.total_objects | numeric | | 1 |
 summary.total_objects_successful | numeric | | 1 |
+action_result.parameter.credentials | password | `aws credentials` | |
 
 ## action: 'add parameter'
 
@@ -484,6 +490,7 @@ action_result.summary.status | string | | Successfully added parameter |
 action_result.message | string | | Status: Successfully added parameter |
 summary.total_objects | numeric | | 1 |
 summary.total_objects_successful | numeric | | 1 |
+action_result.parameter.credentials | password | `aws credentials` | |
 
 ## action: 'describe instance'
 
@@ -534,6 +541,7 @@ action_result.summary.status | string | | Successfully retrieved instance inform
 action_result.message | string | | Status: Successfully retrieved instance information |
 summary.total_objects | numeric | | 1 |
 summary.total_objects_successful | numeric | | 1 |
+action_result.parameter.credentials | password | `aws credentials` | |
 
 ______________________________________________________________________
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 **comment** | optional | User-specified information about the command, such as a brief description of what the command should do | string | |
 **output_s3_bucket_name** | optional | The name of the existing S3 bucket where command execution responses should be stored | string | |
 **save_output_to_vault** | optional | Store the output of the command into the vault | boolean | |
-**credentials** | optional | Assumed role credentials | string | `aws credentials` |
+**credentials** | optional | Assumed role credentials | password | `aws credentials` |
 
 #### Action Output
 
@@ -147,7 +147,6 @@ action_result.summary.status | string | | Successfully executed program |
 action_result.message | string | | Status: Successfully executed program, Created vault id: 6f3832d6a9dd6e41533f9648052c07f2379ec6fa |
 summary.total_objects | numeric | | 1 2 |
 summary.total_objects_successful | numeric | | 1 0 |
-action_result.parameter.credentials | string | `aws credentials` | {'AccessKeyId': 'REDACTED', 'Expiration': '2021-06-07 22:28:04', 'SecretAccessKey': 'REDACTED', 'SessionToken': 'REDACTED'} |
 
 ## action: 'get file'
 
@@ -163,7 +162,7 @@ PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 **instance_id** | required | The AWS Instance ID of where to grab the file from | string | `aws instance id` |
 **platform_type** | required | The operating system of the instance | string | |
 **file_path** | required | Full path of the file to download (include filename) | string | |
-**credentials** | optional | Assumed role credentials | string | `aws credentials` |
+**credentials** | optional | Assumed role credentials | password | `aws credentials` |
 
 #### Action Output
 
@@ -213,7 +212,6 @@ action_result.summary.status | string | | Successfully downloaded file into the 
 action_result.message | string | | Status: Successfully downloaded file into the vault, Created vault id: 3fa5db539d7bceec01ac4c100481aa5682766d33 |
 summary.total_objects | numeric | | 1 |
 summary.total_objects_successful | numeric | | 1 |
-action_result.parameter.credentials | string | `aws credentials` | {'AccessKeyId': 'REDACTED', 'Expiration': '2021-06-07 22:28:04', 'SecretAccessKey': 'REDACTED', 'SessionToken': 'REDACTED'} |
 
 ## action: 'run document'
 
@@ -236,7 +234,7 @@ PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 **timeout_seconds** | optional | If this time is reached and the command has not already started running, it will not run | numeric | |
 **comment** | optional | User-specified information about the command, such as a brief description of what the command should do | string | |
 **output_s3_bucket_name** | optional | The name of the S3 bucket where command execution responses should be stored | string | |
-**credentials** | optional | Assumed role credentials | string | `aws credentials` |
+**credentials** | optional | Assumed role credentials | password | `aws credentials` |
 
 #### Action Output
 
@@ -288,7 +286,6 @@ action_result.summary.status | string | | Successfully sent command |
 action_result.message | string | | Status: Successfully sent command |
 summary.total_objects | numeric | | 1 |
 summary.total_objects_successful | numeric | | 1 |
-action_result.parameter.credentials | string | `aws credentials` | {'AccessKeyId': 'REDACTED', 'Expiration': '2021-06-07 22:28:04', 'SecretAccessKey': 'REDACTED', 'SessionToken': 'REDACTED'} |
 
 ## action: 'list commands'
 
@@ -304,7 +301,7 @@ PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 **command_id** | optional | If provided, lists only the specified command | string | `aws command id` |
 **instance_id** | optional | Lists commands issued against this instance ID | string | `aws instance id` |
 **max_results** | optional | The maximum number of items to return for this call | numeric | |
-**credentials** | optional | Assumed role credentials | string | `aws credentials` |
+**credentials** | optional | Assumed role credentials | password | `aws credentials` |
 
 #### Action Output
 
@@ -355,7 +352,6 @@ action_result.summary.num_commands | numeric | | 43 1 |
 action_result.message | string | | Num commands: 43 Num commands: 1 |
 summary.total_objects | numeric | | 1 |
 summary.total_objects_successful | numeric | | 1 |
-action_result.parameter.credentials | string | `aws credentials` | {'AccessKeyId': 'REDACTED', 'Expiration': '2021-06-07 22:28:04', 'SecretAccessKey': 'REDACTED', 'SessionToken': 'REDACTED'} |
 
 ## action: 'list documents'
 
@@ -373,7 +369,7 @@ PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 **platform_type** | optional | The OS platform type that the document can execute on (i.e. Windows, Linux) | string | |
 **document_type** | optional | The type of document | string | |
 **max_results** | optional | The maximum number of items to return for this call | numeric | |
-**credentials** | optional | Assumed role credentials | string | `aws credentials` |
+**credentials** | optional | Assumed role credentials | password | `aws credentials` |
 
 #### Action Output
 
@@ -397,7 +393,6 @@ action_result.summary.num_documents | numeric | | 5 |
 action_result.message | string | | Num documents: 5 |
 summary.total_objects | numeric | | 1 |
 summary.total_objects_successful | numeric | | 1 |
-action_result.parameter.credentials | string | `aws credentials` | {'AccessKeyId': 'REDACTED', 'Expiration': '2021-06-07 22:28:04', 'SecretAccessKey': 'REDACTED', 'SessionToken': 'REDACTED'} |
 
 ## action: 'get parameter'
 
@@ -412,7 +407,7 @@ PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 --------- | -------- | ----------- | ---- | --------
 **name** | required | The name of the parameter that you want to query | string | `aws parameter name` |
 **with_decryption** | optional | Check to decrypt values of secure string parameters. This flag is ignored for String and StringList parameter types | boolean | |
-**credentials** | optional | Assumed role credentials | string | `aws credentials` |
+**credentials** | optional | Assumed role credentials | password | `aws credentials` |
 
 #### Action Output
 
@@ -440,7 +435,6 @@ action_result.summary.status | string | | Successfully retrieved parameter |
 action_result.message | string | | Status: Successfully retrieved parameter |
 summary.total_objects | numeric | | 1 |
 summary.total_objects_successful | numeric | | 1 |
-action_result.parameter.credentials | string | `aws credentials` | {'AccessKeyId': 'REDACTED', 'Expiration': '2021-06-07 22:28:04', 'SecretAccessKey': 'REDACTED', 'SessionToken': 'REDACTED'} |
 
 ## action: 'add parameter'
 
@@ -462,7 +456,7 @@ PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 **key_id** | optional | The KMS Key ID that you want to use to encrypt a SecureString parameter. Defaults to the AWS KMS key automatically assigned to your AWS account if no key ID is provided | string | |
 **overwrite** | optional | Overwrite an existing parameter | boolean | |
 **allowed_pattern** | optional | A regular expression used to validate the parameter value. For example, for String types with values restricted to numbers, you can specify the following: AllowedPattern=^d+$ | string | |
-**credentials** | optional | Assumed role credentials | string | `aws credentials` |
+**credentials** | optional | Assumed role credentials | password | `aws credentials` |
 
 #### Action Output
 
@@ -490,7 +484,6 @@ action_result.summary.status | string | | Successfully added parameter |
 action_result.message | string | | Status: Successfully added parameter |
 summary.total_objects | numeric | | 1 |
 summary.total_objects_successful | numeric | | 1 |
-action_result.parameter.credentials | string | `aws credentials` | {'AccessKeyId': 'REDACTED', 'Expiration': '2021-06-07 22:28:04', 'SecretAccessKey': 'REDACTED', 'SessionToken': 'REDACTED'} |
 
 ## action: 'describe instance'
 
@@ -504,7 +497,7 @@ Read only: **True**
 PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 --------- | -------- | ----------- | ---- | --------
 **instance_id** | required | The AWS instance ID | string | `aws instance id` |
-**credentials** | optional | Assumed role credentials | string | `aws credentials` |
+**credentials** | optional | Assumed role credentials | password | `aws credentials` |
 
 #### Action Output
 
@@ -541,7 +534,6 @@ action_result.summary.status | string | | Successfully retrieved instance inform
 action_result.message | string | | Status: Successfully retrieved instance information |
 summary.total_objects | numeric | | 1 |
 summary.total_objects_successful | numeric | | 1 |
-action_result.parameter.credentials | string | `aws credentials` | {'AccessKeyId': 'REDACTED', 'Expiration': '2021-06-07 22:28:04', 'SecretAccessKey': 'REDACTED', 'SessionToken': 'REDACTED'} |
 
 ______________________________________________________________________
 

--- a/awssystemsmanager.json
+++ b/awssystemsmanager.json
@@ -542,6 +542,13 @@
                         1,
                         0
                     ]
+                },
+                {
+                    "data_path": "action_result.parameter.credentials",
+                    "data_type": "password",
+                    "contains": [
+                        "aws credentials"
+                    ]
                 }
             ],
             "render": {
@@ -899,6 +906,13 @@
                     "data_type": "numeric",
                     "example_values": [
                         1
+                    ]
+                },
+                {
+                    "data_path": "action_result.parameter.credentials",
+                    "data_type": "password",
+                    "contains": [
+                        "aws credentials"
                     ]
                 }
             ],
@@ -1313,6 +1327,13 @@
                     "example_values": [
                         1
                     ]
+                },
+                {
+                    "data_path": "action_result.parameter.credentials",
+                    "data_type": "password",
+                    "contains": [
+                        "aws credentials"
+                    ]
                 }
             ],
             "render": {
@@ -1697,6 +1718,13 @@
                     "example_values": [
                         1
                     ]
+                },
+                {
+                    "data_path": "action_result.parameter.credentials",
+                    "data_type": "password",
+                    "contains": [
+                        "aws credentials"
+                    ]
                 }
             ],
             "render": {
@@ -1897,6 +1925,13 @@
                     "data_type": "numeric",
                     "example_values": [
                         1
+                    ]
+                },
+                {
+                    "data_path": "action_result.parameter.credentials",
+                    "data_type": "password",
+                    "contains": [
+                        "aws credentials"
                     ]
                 }
             ],
@@ -2108,6 +2143,13 @@
                     "data_type": "numeric",
                     "example_values": [
                         1
+                    ]
+                },
+                {
+                    "data_path": "action_result.parameter.credentials",
+                    "data_type": "password",
+                    "contains": [
+                        "aws credentials"
                     ]
                 }
             ],
@@ -2346,6 +2388,13 @@
                     "data_type": "numeric",
                     "example_values": [
                         1
+                    ]
+                },
+                {
+                    "data_path": "action_result.parameter.credentials",
+                    "data_type": "password",
+                    "contains": [
+                        "aws credentials"
                     ]
                 }
             ],
@@ -2614,6 +2663,13 @@
                     "data_type": "numeric",
                     "example_values": [
                         1
+                    ]
+                },
+                {
+                    "data_path": "action_result.parameter.credentials",
+                    "data_type": "password",
+                    "contains": [
+                        "aws credentials"
                     ]
                 }
             ],

--- a/awssystemsmanager.json
+++ b/awssystemsmanager.json
@@ -150,7 +150,7 @@
                 },
                 "credentials": {
                     "description": "Assumed role credentials",
-                    "data_type": "string",
+                    "data_type": "password",
                     "primary": true,
                     "contains": [
                         "aws credentials"
@@ -542,16 +542,6 @@
                         1,
                         0
                     ]
-                },
-                {
-                    "data_path": "action_result.parameter.credentials",
-                    "data_type": "string",
-                    "example_values": [
-                        "{'AccessKeyId': 'REDACTED', 'Expiration': '2021-06-07 22:28:04', 'SecretAccessKey': 'REDACTED', 'SessionToken': 'REDACTED'}"
-                    ],
-                    "contains": [
-                        "aws credentials"
-                    ]
                 }
             ],
             "render": {
@@ -594,7 +584,7 @@
                 },
                 "credentials": {
                     "description": "Assumed role credentials",
-                    "data_type": "string",
+                    "data_type": "password",
                     "primary": true,
                     "contains": [
                         "aws credentials"
@@ -910,16 +900,6 @@
                     "example_values": [
                         1
                     ]
-                },
-                {
-                    "data_path": "action_result.parameter.credentials",
-                    "data_type": "string",
-                    "example_values": [
-                        "{'AccessKeyId': 'REDACTED', 'Expiration': '2021-06-07 22:28:04', 'SecretAccessKey': 'REDACTED', 'SessionToken': 'REDACTED'}"
-                    ],
-                    "contains": [
-                        "aws credentials"
-                    ]
                 }
             ],
             "render": {
@@ -994,7 +974,7 @@
                 },
                 "credentials": {
                     "description": "Assumed role credentials",
-                    "data_type": "string",
+                    "data_type": "password",
                     "primary": true,
                     "contains": [
                         "aws credentials"
@@ -1333,16 +1313,6 @@
                     "example_values": [
                         1
                     ]
-                },
-                {
-                    "data_path": "action_result.parameter.credentials",
-                    "data_type": "string",
-                    "example_values": [
-                        "{'AccessKeyId': 'REDACTED', 'Expiration': '2021-06-07 22:28:04', 'SecretAccessKey': 'REDACTED', 'SessionToken': 'REDACTED'}"
-                    ],
-                    "contains": [
-                        "aws credentials"
-                    ]
                 }
             ],
             "render": {
@@ -1382,7 +1352,7 @@
                 },
                 "credentials": {
                     "description": "Assumed role credentials",
-                    "data_type": "string",
+                    "data_type": "password",
                     "primary": true,
                     "contains": [
                         "aws credentials"
@@ -1727,16 +1697,6 @@
                     "example_values": [
                         1
                     ]
-                },
-                {
-                    "data_path": "action_result.parameter.credentials",
-                    "data_type": "string",
-                    "example_values": [
-                        "{'AccessKeyId': 'REDACTED', 'Expiration': '2021-06-07 22:28:04', 'SecretAccessKey': 'REDACTED', 'SessionToken': 'REDACTED'}"
-                    ],
-                    "contains": [
-                        "aws credentials"
-                    ]
                 }
             ],
             "render": {
@@ -1789,7 +1749,7 @@
                 },
                 "credentials": {
                     "description": "Assumed role credentials",
-                    "data_type": "string",
+                    "data_type": "password",
                     "primary": true,
                     "contains": [
                         "aws credentials"
@@ -1938,16 +1898,6 @@
                     "example_values": [
                         1
                     ]
-                },
-                {
-                    "data_path": "action_result.parameter.credentials",
-                    "data_type": "string",
-                    "example_values": [
-                        "{'AccessKeyId': 'REDACTED', 'Expiration': '2021-06-07 22:28:04', 'SecretAccessKey': 'REDACTED', 'SessionToken': 'REDACTED'}"
-                    ],
-                    "contains": [
-                        "aws credentials"
-                    ]
                 }
             ],
             "render": {
@@ -1979,7 +1929,7 @@
                 },
                 "credentials": {
                     "description": "Assumed role credentials",
-                    "data_type": "string",
+                    "data_type": "password",
                     "primary": true,
                     "contains": [
                         "aws credentials"
@@ -2159,16 +2109,6 @@
                     "example_values": [
                         1
                     ]
-                },
-                {
-                    "data_path": "action_result.parameter.credentials",
-                    "data_type": "string",
-                    "example_values": [
-                        "{'AccessKeyId': 'REDACTED', 'Expiration': '2021-06-07 22:28:04', 'SecretAccessKey': 'REDACTED', 'SessionToken': 'REDACTED'}"
-                    ],
-                    "contains": [
-                        "aws credentials"
-                    ]
                 }
             ],
             "render": {
@@ -2234,7 +2174,7 @@
                 },
                 "credentials": {
                     "description": "Assumed role credentials",
-                    "data_type": "string",
+                    "data_type": "password",
                     "primary": true,
                     "contains": [
                         "aws credentials"
@@ -2407,16 +2347,6 @@
                     "example_values": [
                         1
                     ]
-                },
-                {
-                    "data_path": "action_result.parameter.credentials",
-                    "data_type": "string",
-                    "example_values": [
-                        "{'AccessKeyId': 'REDACTED', 'Expiration': '2021-06-07 22:28:04', 'SecretAccessKey': 'REDACTED', 'SessionToken': 'REDACTED'}"
-                    ],
-                    "contains": [
-                        "aws credentials"
-                    ]
                 }
             ],
             "render": {
@@ -2443,7 +2373,7 @@
                 },
                 "credentials": {
                     "description": "Assumed role credentials",
-                    "data_type": "string",
+                    "data_type": "password",
                     "primary": true,
                     "contains": [
                         "aws credentials"
@@ -2684,16 +2614,6 @@
                     "data_type": "numeric",
                     "example_values": [
                         1
-                    ]
-                },
-                {
-                    "data_path": "action_result.parameter.credentials",
-                    "data_type": "string",
-                    "example_values": [
-                        "{'AccessKeyId': 'REDACTED', 'Expiration': '2021-06-07 22:28:04', 'SecretAccessKey': 'REDACTED', 'SessionToken': 'REDACTED'}"
-                    ],
-                    "contains": [
-                        "aws credentials"
                     ]
                 }
             ],

--- a/awssystemsmanager.json
+++ b/awssystemsmanager.json
@@ -542,13 +542,6 @@
                         1,
                         0
                     ]
-                },
-                {
-                    "data_path": "action_result.parameter.credentials",
-                    "data_type": "password",
-                    "contains": [
-                        "aws credentials"
-                    ]
                 }
             ],
             "render": {
@@ -906,13 +899,6 @@
                     "data_type": "numeric",
                     "example_values": [
                         1
-                    ]
-                },
-                {
-                    "data_path": "action_result.parameter.credentials",
-                    "data_type": "password",
-                    "contains": [
-                        "aws credentials"
                     ]
                 }
             ],
@@ -1327,13 +1313,6 @@
                     "example_values": [
                         1
                     ]
-                },
-                {
-                    "data_path": "action_result.parameter.credentials",
-                    "data_type": "password",
-                    "contains": [
-                        "aws credentials"
-                    ]
                 }
             ],
             "render": {
@@ -1718,13 +1697,6 @@
                     "example_values": [
                         1
                     ]
-                },
-                {
-                    "data_path": "action_result.parameter.credentials",
-                    "data_type": "password",
-                    "contains": [
-                        "aws credentials"
-                    ]
                 }
             ],
             "render": {
@@ -1925,13 +1897,6 @@
                     "data_type": "numeric",
                     "example_values": [
                         1
-                    ]
-                },
-                {
-                    "data_path": "action_result.parameter.credentials",
-                    "data_type": "password",
-                    "contains": [
-                        "aws credentials"
                     ]
                 }
             ],
@@ -2143,13 +2108,6 @@
                     "data_type": "numeric",
                     "example_values": [
                         1
-                    ]
-                },
-                {
-                    "data_path": "action_result.parameter.credentials",
-                    "data_type": "password",
-                    "contains": [
-                        "aws credentials"
                     ]
                 }
             ],
@@ -2388,13 +2346,6 @@
                     "data_type": "numeric",
                     "example_values": [
                         1
-                    ]
-                },
-                {
-                    "data_path": "action_result.parameter.credentials",
-                    "data_type": "password",
-                    "contains": [
-                        "aws credentials"
                     ]
                 }
             ],
@@ -2663,13 +2614,6 @@
                     "data_type": "numeric",
                     "example_values": [
                         1
-                    ]
-                },
-                {
-                    "data_path": "action_result.parameter.credentials",
-                    "data_type": "password",
-                    "contains": [
-                        "aws credentials"
                     ]
                 }
             ],

--- a/awssystemsmanager_connector.py
+++ b/awssystemsmanager_connector.py
@@ -190,7 +190,7 @@ class AwsSystemsManagerConnector(BaseConnector):
         temp_credentials = dict()
         if param and "credentials" in param:
             try:
-                temp_credentials = ast.literal_eval(param["credentials"])
+                temp_credentials = ast.literal_eval(param.get("credentials", ""))
                 self._access_key = temp_credentials.get("AccessKeyId", "")
                 self._secret_key = temp_credentials.get("SecretAccessKey", "")
                 self._session_token = temp_credentials.get("SessionToken", "")
@@ -227,7 +227,7 @@ class AwsSystemsManagerConnector(BaseConnector):
         temp_credentials = dict()
         if param and "credentials" in param:
             try:
-                temp_credentials = ast.literal_eval(param["credentials"])
+                temp_credentials = ast.literal_eval(param.get("credentials", ""))
                 self._access_key = temp_credentials.get("AccessKeyId", "")
                 self._secret_key = temp_credentials.get("SecretAccessKey", "")
                 self._session_token = temp_credentials.get("SessionToken", "")

--- a/awssystemsmanager_connector.py
+++ b/awssystemsmanager_connector.py
@@ -262,7 +262,7 @@ class AwsSystemsManagerConnector(BaseConnector):
     def _get_s3_bucket(self, action_result, output_s3_bucket_name, param):
         self._create_s3_client(action_result, param)
 
-        ret_val, resp_json = self._make_boto_call(action_result, "get_bucket_accelerate_configuration", Bucket=output_s3_bucket_name)
+        ret_val, _resp_json = self._make_boto_call(action_result, "get_bucket_accelerate_configuration", Bucket=output_s3_bucket_name)
 
         return ret_val
 
@@ -276,9 +276,9 @@ class AwsSystemsManagerConnector(BaseConnector):
 
         # boto3 bug
         if location["LocationConstraint"] == "us-east-1":
-            ret_val, resp_json = self._make_boto_call(action_result, "create_bucket", Bucket=output_s3_bucket_name)
+            ret_val, _resp_json = self._make_boto_call(action_result, "create_bucket", Bucket=output_s3_bucket_name)
         else:
-            ret_val, resp_json = self._make_boto_call(
+            ret_val, _resp_json = self._make_boto_call(
                 action_result, "create_bucket", Bucket=output_s3_bucket_name, CreateBucketConfiguration=location
             )
 
@@ -355,7 +355,7 @@ class AwsSystemsManagerConnector(BaseConnector):
             return action_result.get_status()
 
         # make rest call
-        ret_val, resp_json = self._make_boto_call(action_result, "list_commands", MaxResults=1)
+        ret_val, _resp_json = self._make_boto_call(action_result, "list_commands", MaxResults=1)
 
         if phantom.is_fail(ret_val):
             self.save_progress("Test Connectivity Failed.")

--- a/awssystemsmanager_connector.py
+++ b/awssystemsmanager_connector.py
@@ -59,6 +59,10 @@ class AwsSystemsManagerConnector(BaseConnector):
         self._proxy = None
         self._python_version = None
 
+    @staticmethod
+    def _sanitize_action_parameters(param):
+        return {key: value for key, value in param.items() if key != "credentials"}
+
     def _sanitize_data(self, cur_obj):
         try:
             json.dumps(cur_obj)
@@ -343,7 +347,7 @@ class AwsSystemsManagerConnector(BaseConnector):
 
     def _handle_test_connectivity(self, param):
         # Add an action result object to self (BaseConnector) to represent the action for this param
-        action_result = self.add_action_result(ActionResult(dict(param)))
+        action_result = self.add_action_result(ActionResult(self._sanitize_action_parameters(param)))
 
         self.save_progress("Querying AWS to check credentials")
 
@@ -389,7 +393,7 @@ class AwsSystemsManagerConnector(BaseConnector):
         self.save_progress(f"In action handler for: {self.get_action_identifier()}")
 
         # Add an action result object to self (BaseConnector) to represent the action for this param
-        action_result = self.add_action_result(ActionResult(dict(param)))
+        action_result = self.add_action_result(ActionResult(self._sanitize_action_parameters(param)))
         instance_id = param["instance_id"]
         platform_type = param["platform_type"]
         if platform_type == "Windows":
@@ -523,7 +527,7 @@ class AwsSystemsManagerConnector(BaseConnector):
         self.save_progress(f"In action handler for: {self.get_action_identifier()}")
 
         # Add an action result object to self (BaseConnector) to represent the action for this param
-        action_result = self.add_action_result(ActionResult(dict(param)))
+        action_result = self.add_action_result(ActionResult(self._sanitize_action_parameters(param)))
 
         output_s3_bucket_name = param.get("output_s3_bucket_name")
         output_s3_key_prefix = param.get("output_s3_key_prefix")
@@ -590,7 +594,7 @@ class AwsSystemsManagerConnector(BaseConnector):
         self.save_progress(f"In action handler for: {self.get_action_identifier()}")
 
         # Add an action result object to self (BaseConnector) to represent the action for this param
-        action_result = self.add_action_result(ActionResult(dict(param)))
+        action_result = self.add_action_result(ActionResult(self._sanitize_action_parameters(param)))
 
         if not self._create_client(action_result, param):
             return action_result.get_status()
@@ -654,7 +658,7 @@ class AwsSystemsManagerConnector(BaseConnector):
         self.save_progress(f"In action handler for: {self.get_action_identifier()}")
 
         # Add an action result object to self (BaseConnector) to represent the action for this param
-        action_result = self.add_action_result(ActionResult(dict(param)))
+        action_result = self.add_action_result(ActionResult(self._sanitize_action_parameters(param)))
 
         if not self._create_client(action_result, param):
             return action_result.get_status()
@@ -733,7 +737,7 @@ class AwsSystemsManagerConnector(BaseConnector):
         self.save_progress(f"In action handler for: {self.get_action_identifier()}")
 
         # Add an action result object to self (BaseConnector) to represent the action for this param
-        action_result = self.add_action_result(ActionResult(dict(param)))
+        action_result = self.add_action_result(ActionResult(self._sanitize_action_parameters(param)))
 
         if not self._create_client(action_result, param):
             return action_result.get_status()
@@ -764,7 +768,7 @@ class AwsSystemsManagerConnector(BaseConnector):
         self.save_progress(f"In action handler for: {self.get_action_identifier()}")
 
         # Add an action result object to self (BaseConnector) to represent the action for this param
-        action_result = self.add_action_result(ActionResult(dict(param)))
+        action_result = self.add_action_result(ActionResult(self._sanitize_action_parameters(param)))
 
         if not self._create_client(action_result, param):
             return action_result.get_status()
@@ -807,7 +811,7 @@ class AwsSystemsManagerConnector(BaseConnector):
         self.save_progress(f"In action handler for: {self.get_action_identifier()}")
 
         # Add an action result object to self (BaseConnector) to represent the action for this param
-        action_result = self.add_action_result(ActionResult(dict(param)))
+        action_result = self.add_action_result(ActionResult(self._sanitize_action_parameters(param)))
 
         if not self._create_client(action_result, param):
             return action_result.get_status()

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* Prevent action-scoped AWS credentials from being retained in action results.


### PR DESCRIPTION
Written by Codex.

## Summary

- Mark temporary AWS credentials as password-typed action input.
- Exclude action-scoped credentials before parameters are retained in ActionResult.
- Remove credential parameter paths from action output metadata.
- Refresh shared quality hooks and their generated maintenance artifacts.

## Tracking

- [PAPP-37946](https://splunk.atlassian.net/browse/PAPP-37946)
- [PSAAS-32390](https://splunk.atlassian.net/browse/PSAAS-32390)
- [PSAAS-32390](https://splunk.atlassian.net/browse/PSAAS-32390)
- Parent epic: [ESPM-5228](https://splunk.atlassian.net/browse/ESPM-5228)

## Quality gate

- Full pre-commit suite passes locally and the hosted pre-commit check passes at the corrected head.
- Source compilation passes locally.
- Hosted compile rerun passed on 2026-08-07; no connector-code compile failure remains.

- Security scans are non-blocking under the connector quality policy; integration failures are ignored unless they implicate the changed code.

## Release impact

Asset configuration and credential use are unchanged. The action history no longer retains temporary credential material.

Merge strategy: merge commit only; do not squash.
